### PR TITLE
feat: enhance config and fix builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(hybrid-compute LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Add conda environment to CMAKE_PREFIX_PATH for OpenCV
+if(APPLE)
+    set(CMAKE_PREFIX_PATH "$ENV{HOME}/miniconda3" ${CMAKE_PREFIX_PATH})
+endif()
+
 find_package(OpenCV REQUIRED)
 find_package(CUDAToolkit)
 

--- a/cloud_gpu/upscale.cu
+++ b/cloud_gpu/upscale.cu
@@ -54,8 +54,17 @@ __global__ void bicubicUpscaleKernel(uchar* input, uchar* output, int in_w, int 
     } while (0)
 
 int main(int argc, char** argv) {
+    if (argc > 4) {
+        std::cerr << "Usage: ./upscale [input_file] [output_file] [scale]\n";
+        return -1;
+    }
     std::string input_file = (argc > 1) ? argv[1] : "input_tile.jpg";
     std::string output_file = (argc > 2) ? argv[2] : "output_tile.jpg";
+    int scale = (argc > 3) ? std::stoi(argv[3]) : 2;
+    if (scale <= 1) {
+        std::cerr << "Error: scale must be greater than 1\n";
+        return -1;
+    }
 
     // Load the input image
     cv::Mat input = cv::imread(input_file);
@@ -67,7 +76,6 @@ int main(int argc, char** argv) {
     // Calculate dimensions
     int in_w = input.cols;
     int in_h = input.rows;
-    int scale = 2;  // Upscaling factor
     int out_w = in_w * scale;
     int out_h = in_h * scale;
 

--- a/scripts/stitch.py
+++ b/scripts/stitch.py
@@ -6,15 +6,21 @@ import sys
 print("Starting stitch")
 sys.stdout.flush()
 
-def stitch_tiles(input_dir, output_path, tile_count=16):
+def stitch_tiles(input_dir, output_path):
     tiles = []
-    for i in range(tile_count):
-        img = cv2.imread(os.path.join(input_dir, f"tile_{i}.jpg"))
+    tile_files = sorted([f for f in os.listdir(input_dir) if f.startswith("tile_") and f.endswith(".jpg")])
+    if not tile_files:
+        raise ValueError("No tile files found in input directory")
+    for tile_file in tile_files:
+        img = cv2.imread(os.path.join(input_dir, tile_file))
         if img is None:
-            raise ValueError(f"Could not load tile_{i}.jpg")
+            raise ValueError(f"Could not load {tile_file}")
         tiles.append(img)
+    tile_count = len(tiles)
     tiles = np.array(tiles)
     grid_size = int(np.sqrt(tile_count))
+    if grid_size * grid_size != tile_count:
+        raise ValueError(f"Tile count {tile_count} is not a perfect square")
     stitched = cv2.vconcat([cv2.hconcat(list(tiles_row)) for tiles_row in np.array_split(tiles, grid_size)])
     print("Stitched shape:", stitched.shape)
     print("About to write to", output_path)
@@ -27,4 +33,9 @@ def stitch_tiles(input_dir, output_path, tile_count=16):
     sys.stdout.flush()
 
 if __name__ == "__main__":
-    stitch_tiles("test_images/upscaled", "test_images/final_output.jpg")
+    if len(sys.argv) != 3:
+        print("Usage: python3 stitch.py <input_dir> <output_path>")
+        sys.exit(1)
+    input_dir = sys.argv[1]
+    output_path = sys.argv[2]
+    stitch_tiles(input_dir, output_path)

--- a/src/preprocess.cpp
+++ b/src/preprocess.cpp
@@ -7,13 +7,18 @@
 namespace fs = std::filesystem;
 
 int main(int argc, char** argv) {
-    if (argc != 3) {
-        std::cerr << "Usage: ./preprocess <input_folder> <output_folder>\n";
+    if (argc < 3 || argc > 4) {
+        std::cerr << "Usage: ./preprocess <input_folder> <output_folder> [tile_size]\n";
         return -1;
     }
 
     std::string input_folder = argv[1];
     std::string output_folder = argv[2];
+    int tile_size = (argc == 4) ? std::stoi(argv[3]) : 64;
+    if (tile_size <= 0) {
+        std::cerr << "Error: tile_size must be positive\n";
+        return -1;
+    }
 
     // Create output folder if it does not exist
     if (!fs::exists(output_folder)) {
@@ -27,8 +32,6 @@ int main(int argc, char** argv) {
                 std::cerr << "Error loading image: " << entry.path() << "\n";
                 continue;
             }
-
-            int tile_size = 64;
             std::vector<cv::Mat> tiles = splitImageIntoTiles(image, tile_size);
 
             // Save tiles to output folder

--- a/tests/test_stitch.py
+++ b/tests/test_stitch.py
@@ -17,9 +17,9 @@ def test_stitch_tiles_success(tmp_path):
     tile_count = 16
     tile_size = (10, 10)
     create_dummy_tiles(input_dir, tile_count, tile_size)
-    
-    stitch_tiles(str(input_dir), str(output_path), tile_count)
-    
+
+    stitch_tiles(str(input_dir), str(output_path))
+
     assert output_path.exists()
     stitched = cv2.imread(str(output_path))
     assert stitched is not None
@@ -31,6 +31,6 @@ def test_stitch_tiles_missing_tile(tmp_path):
     output_path = tmp_path / "output.jpg"
     tile_count = 16
     create_dummy_tiles(input_dir, tile_count - 1)  # Missing last tile
-    
-    with pytest.raises(ValueError, match="Could not load tile_15.jpg"):
-        stitch_tiles(str(input_dir), str(output_path), tile_count)
+
+    with pytest.raises(ValueError, match="not a perfect square"):
+        stitch_tiles(str(input_dir), str(output_path))


### PR DESCRIPTION
This PR introduces improvements to the hybrid-compute image upscaling tool:

- Make tile_size, upscale scale, and stitch inputs configurable via CLI args
- Fix CMake to locate OpenCV on macOS
- Add validation for parameters
- Update tests to match new stitch API

All changes tested: build succeeds, tests pass. Branch rebased on main.