### PR TITLE
chore: activate branch ruleset

### DIFF
--- a/.github/rulesets/main-branch-protection.active.json
+++ b/.github/rulesets/main-branch-protection.active.json
@@ -1,7 +1,7 @@
 {
   "name": "main branch protection",
   "target": "branch",
-  "enforcement": "disabled",
+  "enforcement": "active",
   "bypass_actors": [],
   "conditions": {
     "ref_name": {


### PR DESCRIPTION
Sync the repository-managed ruleset JSON with the now-active GitHub ruleset.

- rename the local ruleset file to `main-branch-protection.active.json`
- set enforcement to `active`

This change had to merge through a PR because the main branch ruleset was already enforced.