### PR TITLE
chore: refine bot workflow comments

### DIFF
--- a/.github/scripts/comment_fix.py
+++ b/.github/scripts/comment_fix.py
@@ -21,13 +21,42 @@ if not pr_num:
     )
     pr_num = result.stdout.strip()
 
-body = """## Fix Applied
+marker = "<!-- pr-issue-fixer -->"
+body = f"""{marker}
 
-Fixed:
-- Added missing permissions to workflow jobs
-- Applied pre-commit auto-fixes
+## Update
 
-Changes have been pushed to this PR.
+☑️ I applied the requested fixes and pushed them to this PR.
+
+What changed:
+- added the missing workflow permissions
+- applied the pre-commit fixes
 """
 
-subprocess.run(["/usr/bin/gh", "pr", "comment", pr_num, "--body", body], check=True)
+comments = subprocess.run(
+    ["/usr/bin/gh", "api", f"repos/{os.environ['GITHUB_REPOSITORY']}/issues/{pr_num}/comments"],
+    capture_output=True,
+    text=True,
+    check=True,
+)
+
+existing_comment_id = ""
+for comment in json.loads(comments.stdout):
+    if comment["user"]["login"] == "github-actions[bot]" and marker in comment["body"]:
+        existing_comment_id = str(comment["id"])
+
+if existing_comment_id:
+    subprocess.run(
+        [
+            "/usr/bin/gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{os.environ['GITHUB_REPOSITORY']}/issues/comments/{existing_comment_id}",
+            "-f",
+            f"body={body}",
+        ],
+        check=True,
+    )
+else:
+    subprocess.run(["/usr/bin/gh", "pr", "comment", pr_num, "--body", body], check=True)

--- a/.github/scripts/comment_fix.py
+++ b/.github/scripts/comment_fix.py
@@ -22,11 +22,17 @@ if not pr_num:
     pr_num = result.stdout.strip()
 
 marker = "<!-- pr-issue-fixer -->"
+commit_sha = os.environ.get("FIX_COMMIT_SHA", "").strip()
+commit_line = ""
+if commit_sha:
+    commit_line = f"\nCommit: `{commit_sha}`\n"
+
 body = f"""{marker}
 
 ## Update
 
 ☑️ I applied the requested fixes and pushed them to this PR.
+{commit_line}
 
 What changed:
 - added the missing workflow permissions

--- a/.github/scripts/comment_issues.py
+++ b/.github/scripts/comment_issues.py
@@ -38,17 +38,46 @@ if issues_path.exists():
 elif "ISSUES" in os.environ:
     issues = base64.b64decode(os.environ["ISSUES"]).decode()
 
-body = f"""## PR Analysis
+marker = "<!-- pr-issue-analysis -->"
+body = f"""{marker}
 
-I found issues in this PR:
+## Review note
+
+☑️ I found a few things to fix in this PR.
 
 {issues}
 
-### Fix Commands
+### Commands you can use
 
-- /fix-workflow-permissions - Fix permissions
-- /fix precommit - Fix pre-commit issues
-- /fix all - Apply all fixes
+- `/fix-workflow-permissions` to fix workflow permissions
+- `/fix precommit` to run the pre-commit fixes
+- `/fix all` to apply everything
 """
 
-subprocess.run(["/usr/bin/gh", "pr", "comment", pr_num, "--body", body], check=True)
+comments = subprocess.run(
+    ["/usr/bin/gh", "api", f"repos/{os.environ['GITHUB_REPOSITORY']}/issues/{pr_num}/comments"],
+    capture_output=True,
+    text=True,
+    check=True,
+)
+
+existing_comment_id = ""
+for comment in json.loads(comments.stdout):
+    if comment["user"]["login"] == "github-actions[bot]" and marker in comment["body"]:
+        existing_comment_id = str(comment["id"])
+
+if existing_comment_id:
+    subprocess.run(
+        [
+            "/usr/bin/gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{os.environ['GITHUB_REPOSITORY']}/issues/comments/{existing_comment_id}",
+            "-f",
+            f"body={body}",
+        ],
+        check=True,
+    )
+else:
+    subprocess.run(["/usr/bin/gh", "pr", "comment", pr_num, "--body", body], check=True)

--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -2,30 +2,147 @@
 name: Fix Commit Messages
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Repository branch to rewrite into a new PR branch'
+        required: true
+        type: string
+      base_branch:
+        description: 'Base branch for the follow-up PR'
+        required: false
+        default: 'main'
+        type: string
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   fix:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine branches
+        id: branches
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+          INPUT_SOURCE_BRANCH: ${{ inputs.source_branch }}
+          INPUT_BASE_BRANCH: ${{ inputs.base_branch }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$PR_HEAD_REPO" != "$REPOSITORY" ]; then
+              echo "[INFO] Skipping fork PR because this workflow cannot push to fork branches."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            source_branch="$PR_HEAD_REF"
+            base_branch="$PR_BASE_REF"
+          else
+            source_branch="$INPUT_SOURCE_BRANCH"
+            base_branch="$INPUT_BASE_BRANCH"
+          fi
+
+          if [ -z "$source_branch" ]; then
+            echo "[ERROR] source_branch is required" >&2
+            exit 1
+          fi
+
+          if [ "$source_branch" = "$base_branch" ]; then
+            echo "[ERROR] source_branch and base_branch must differ" >&2
+            exit 1
+          fi
+
+          fix_branch="fix-commit-messages/${source_branch//\//-}-${GITHUB_RUN_ID}"
+          {
+            echo "skip=false"
+            echo "source_branch=$source_branch"
+            echo "base_branch=$base_branch"
+            echo "fix_branch=$fix_branch"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
+        if: steps.branches.outputs.skip != 'true'
         with:
           fetch-depth: 0
+          ref: ${{ steps.branches.outputs.source_branch }}
 
-      - name: Fix commit messages
+      - name: Setup Git
+        if: steps.branches.outputs.skip != 'true'
         run: |
-          git filter-branch -f --msg-filter 'commit_msg=$(cat);
-            commit_msg=$(echo "$commit_msg" | sed "s/ add / /g");
-            commit_msg=$(echo "$commit_msg" | sed "s/^add //");
-            echo "$commit_msg"' HEAD || true
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Force push if changed
+      - name: Rewrite commit messages
+        if: steps.branches.outputs.skip != 'true'
+        id: rewrite
         run: |
-          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
-            git push --force origin main
+          git fetch origin "${{ steps.branches.outputs.base_branch }}"
+          original_head="$(git rev-parse HEAD)"
+          base_commit="$(git merge-base HEAD "origin/${{ steps.branches.outputs.base_branch }}")"
+
+          git filter-branch -f \
+            --msg-filter 'bash scripts/rewrite_msg.sh' \
+            "${base_commit}..HEAD" || true
+
+          rewritten_head="$(git rev-parse HEAD)"
+          if [ "$original_head" = "$rewritten_head" ]; then
+            echo "[INFO] No commit message rewrite was needed."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "[INFO] Rewrote commit messages from"
+            echo "       $original_head to $rewritten_head"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push rewritten branch
+        if: steps.branches.outputs.skip != 'true' && steps.rewrite.outputs.changed == 'true'
+        run: |
+          git checkout -b "${{ steps.branches.outputs.fix_branch }}"
+          git push --force-with-lease origin "${{ steps.branches.outputs.fix_branch }}"
+
+      - name: Open pull request
+        if: steps.branches.outputs.skip != 'true' && steps.rewrite.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing_pr="$(gh pr list \
+            --head "${{ steps.branches.outputs.fix_branch }}" \
+            --base "${{ steps.branches.outputs.base_branch }}" \
+            --state open \
+            --json number \
+            --jq '.[0].number')"
+
+          if [ -n "$existing_pr" ] && [ "$existing_pr" != "null" ]; then
+            echo "[INFO] PR #$existing_pr already exists for rewritten branch."
+            exit 0
+          fi
+
+          pr_title="fix(ci): normalize commit messages"
+          pr_body=$'This PR keeps the same code but rewrites commit messages'
+          pr_body+=$' with the fix workflow.\n\n'
+          pr_body+=$'The workflow now pushes a separate branch and opens a PR, '
+          pr_body+=$'so protected branch rules on `main` stay intact.'
+
+          gh pr create \
+            --base "${{ steps.branches.outputs.base_branch }}" \
+            --head "${{ steps.branches.outputs.fix_branch }}" \
+            --title "$pr_title" \
+            --body "$pr_body"
+
+      - name: Summary
+        if: steps.branches.outputs.skip != 'true'
+        run: |
+          if [ "${{ steps.rewrite.outputs.changed }}" = "true" ]; then
+            echo "[PASS] Rewritten branch pushed: ${{ steps.branches.outputs.fix_branch }}"
+          else
+            echo "[INFO] No rewritten branch was needed."
           fi

--- a/.github/workflows/pr-issue-detector.yml
+++ b/.github/workflows/pr-issue-detector.yml
@@ -54,17 +54,19 @@ jobs:
     steps:
       - name: Get PR info
         id: pr-info
+        env:
+          ISSUE_URL: ${{ github.event.comment.issue_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_URL="${{ github.event.comment.issue_url }}"
-          PR_NUM=$(echo $PR_URL | grep -oP '\d+$')
-          PR_DATA=$(gh pr view $PR_NUM --json headRefName,headRefOid)
+          PR_NUM="$(echo "$ISSUE_URL" | grep -oP '\d+$')"
+          PR_DATA="$(gh pr view "$PR_NUM" --json headRefName,headRefOid)"
           BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
           SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
-          echo "pr_num=$PR_NUM" >> $GITHUB_OUTPUT
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          {
+            echo "pr_num=$PR_NUM"
+            echo "branch=$BRANCH"
+            echo "sha=$SHA"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v6
         with:
@@ -94,14 +96,17 @@ jobs:
         id: commit
         run: |
           if git diff --exit-code --quiet; then
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git config --local user.email "github-actions[bot]@users.noreply.github.com"
             git config --local user.name "github-actions[bot]"
             git add -A
             git commit -m "style: auto-fix PR issues"
-            git push
-            echo "changed=true" >> $GITHUB_OUTPUT
+            git push origin HEAD
+            {
+              echo "changed=true"
+              echo "commit_sha=$(git rev-parse --short HEAD)"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Comment results
@@ -109,3 +114,4 @@ jobs:
         run: python3 .github/scripts/comment_fix.py
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIX_COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}

--- a/.github/workflows/pre-commit-auto-fix.yml
+++ b/.github/workflows/pre-commit-auto-fix.yml
@@ -25,24 +25,32 @@ jobs:
     steps:
       - name: Get PR branch
         id: pr-info
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_URL: ${{ github.event.comment.issue_url }}
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" == "issue_comment" ]; then
-            PR_URL="${{ github.event.comment.issue_url }}"
-            PR_NUM=$(echo $PR_URL | grep -oP '\d+$')
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            PR_NUM="$(echo "$ISSUE_URL" | grep -oP '\d+$')"
             # Retrieve both the branch name and immutable head commit SHA for the PR
-            BRANCH=$(gh pr view $PR_NUM --json headRefName -q '.headRefName')
-            SHA=$(gh pr view $PR_NUM --json headRefOid -q '.headRefOid')
-            echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "sha=$SHA" >> $GITHUB_OUTPUT
-            echo "pr_num=$PR_NUM" >> $GITHUB_OUTPUT
+            BRANCH="$(gh pr view "$PR_NUM" --json headRefName -q '.headRefName')"
+            SHA="$(gh pr view "$PR_NUM" --json headRefOid -q '.headRefOid')"
+            {
+              echo "branch=$BRANCH"
+              echo "sha=$SHA"
+              echo "pr_num=$PR_NUM"
+            } >> "$GITHUB_OUTPUT"
           else
             # For pull_request events, use the immutable head SHA directly
-            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-            echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-            echo "pr_num=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            {
+              echo "branch=$PR_HEAD_REF"
+              echo "sha=$PR_HEAD_SHA"
+              echo "pr_num=$PR_NUMBER"
+            } >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -66,9 +74,9 @@ jobs:
           pre-commit run --all-files || true
 
           if git diff --exit-code --quiet; then
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
             git diff --stat
           fi
 
@@ -77,15 +85,36 @@ jobs:
         run: |
           git add -A
           git commit -m "style: auto-fix pre-commit issues"
-          git push
+          git push origin HEAD
 
       - name: Comment on PR
-        run: |
-          if [ "${{ steps.precommit.outputs.changed }}" == "true" ]; then
-            BODY="✅ Pre-commit fixes have been automatically applied and pushed."
-          else
-            BODY="✅ Pre-commit check ran - no fixes needed."
-          fi
-          gh pr comment ${{ steps.pr-info.outputs.pr_num }} --body "$BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MARKER="<!-- pre-commit-auto-fix -->"
+          if [ "${{ steps.precommit.outputs.changed }}" == "true" ]; then
+            BODY="$(printf '%s\n\n%s\n' \
+              "$MARKER" \
+              '☑️ I applied the pre-commit fixes and pushed them to this branch.')"
+          else
+            BODY="$(printf '%s\n\n%s\n' \
+              "$MARKER" \
+              '☑️ I checked the pre-commit hooks and there was nothing to fix.')"
+          fi
+
+          EXISTING_COMMENT_ID="$(gh api \
+            repos/${{ github.repository }}/issues/${{ steps.pr-info.outputs.pr_num }}/comments \
+            --jq '.[] | select(
+              .user.login == "github-actions[bot]" and
+              (.body | contains("<!-- pre-commit-auto-fix -->"))
+            ) | .id' \
+            | tail -n 1)"
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              repos/${{ github.repository }}/issues/comments/"$EXISTING_COMMENT_ID" \
+              -f body="$BODY" >/dev/null
+          else
+            gh pr comment ${{ steps.pr-info.outputs.pr_num }} --body "$BODY"
+          fi

--- a/.github/workflows/pre-commit-auto-fix.yml
+++ b/.github/workflows/pre-commit-auto-fix.yml
@@ -82,20 +82,25 @@ jobs:
 
       - name: Commit and push fixes
         if: steps.precommit.outputs.changed == 'true'
+        id: pushfix
         run: |
           git add -A
           git commit -m "style: auto-fix pre-commit issues"
           git push origin HEAD
+          echo "commit_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ steps.pushfix.outputs.commit_sha }}
         run: |
           MARKER="<!-- pre-commit-auto-fix -->"
           if [ "${{ steps.precommit.outputs.changed }}" == "true" ]; then
+            MESSAGE="☑️ I applied the pre-commit fixes and pushed"
+            MESSAGE="$MESSAGE commit \`$COMMIT_SHA\` to this branch."
             BODY="$(printf '%s\n\n%s\n' \
               "$MARKER" \
-              '☑️ I applied the pre-commit fixes and pushed them to this branch.')"
+              "$MESSAGE")"
           else
             BODY="$(printf '%s\n\n%s\n' \
               "$MARKER" \

--- a/.github/workflows/pre-commit-auto-fix.yml
+++ b/.github/workflows/pre-commit-auto-fix.yml
@@ -93,19 +93,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ steps.pushfix.outputs.commit_sha }}
+          CURRENT_SHA: ${{ steps.pr-info.outputs.sha }}
         run: |
           MARKER="<!-- pre-commit-auto-fix -->"
           if [ "${{ steps.precommit.outputs.changed }}" == "true" ]; then
             MESSAGE="☑️ I applied the pre-commit fixes and pushed"
             MESSAGE="$MESSAGE commit \`$COMMIT_SHA\` to this branch."
-            BODY="$(printf '%s\n\n%s\n' \
-              "$MARKER" \
-              "$MESSAGE")"
           else
-            BODY="$(printf '%s\n\n%s\n' \
-              "$MARKER" \
-              '☑️ I checked the pre-commit hooks and there was nothing to fix.')"
+            SHORT_SHA="${CURRENT_SHA:0:7}"
+            MESSAGE="☑️ I checked the pre-commit hooks and there was"
+            MESSAGE="$MESSAGE nothing to fix at commit \`$SHORT_SHA\`."
           fi
+
+          BODY="$(printf '%s\n\n%s\n' \
+            "$MARKER" \
+            "$MESSAGE")"
 
           EXISTING_COMMENT_ID="$(gh api \
             repos/${{ github.repository }}/issues/${{ steps.pr-info.outputs.pr_num }}/comments \


### PR DESCRIPTION
This updates the workflow bot messages to sound more natural, keeps their PR comments up to date instead of posting a new one each run, and includes the relevant commit SHA in those status comments.

It also updates the fix workflow so it pushes rewritten commits to a separate branch and opens a PR instead of rewriting and pushing directly to `main`.