### PR TITLE
Potential fix for code scanning alert no. 3248: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -888,8 +888,8 @@ static void *stbiw__sbgrowf(void **arr, int increment, int itemsize) {
   int m = *arr ? 2 * stbiw__sbm(*arr) + increment : increment + 1;
   void *p = STBIW_REALLOC_SIZED(
       *arr ? stbiw__sbraw(*arr) : 0,
-      *arr ? (stbiw__sbm(*arr) * itemsize + sizeof(int) * 2) : 0,
-      itemsize * m + sizeof(int) * 2);
+      *arr ? ((size_t)stbiw__sbm(*arr) * (size_t)itemsize + (size_t)sizeof(int) * 2) : 0,
+      (size_t)itemsize * (size_t)m + (size_t)sizeof(int) * 2);
   STBIW_ASSERT(p);
   if (p) {
     if (!*arr)


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3248](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3248)

The best fix is to ensure allocation-size arithmetic is performed in `size_t` (or another sufficiently wide unsigned type) *before* multiplication, by casting operands prior to `*`.  
In `include/stb_image_write.h`, inside `stbiw__sbgrowf` (around lines 889–892), update both size expressions passed to `STBIW_REALLOC_SIZED`:

- `stbiw__sbm(*arr) * itemsize + sizeof(int) * 2`
- `itemsize * m + sizeof(int) * 2`

to compute in `size_t` via explicit casts on multiplicands and on the additive constant. This preserves behavior while removing overflow-prone intermediate `int` arithmetic.

No new methods/imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
