### PR TITLE
Potential fix for code scanning alert no. 3247: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -1211,7 +1211,7 @@ static void stbiw__encode_png_line(unsigned char *pixels, int stride_bytes,
       stbi__flip_vertically_on_write ? -stride_bytes : stride_bytes;
 
   if (type == 0) {
-    memcpy(line_buffer, z, width * n);
+    memcpy(line_buffer, z, (size_t)width * (size_t)n);
     return;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3247](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3247)

To fix this, ensure multiplication is performed in `size_t` by casting one operand before the multiply at the `memcpy` call site.

Best minimal fix in `include/stb_image_write.h` (around line 1214 in `stbiw__encode_png_line`):
- Change `memcpy(line_buffer, z, width * n);`
- To `memcpy(line_buffer, z, (size_t)width * (size_t)n);`

This prevents intermediate `int` overflow by doing the multiplication in an unsigned type wide enough for buffer sizes (`size_t`), while keeping functionality unchanged for valid inputs. No new imports or helper methods are required (`size_t` is already available via existing headers in this file context).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
