### PR TITLE
Potential fix for code scanning alert no. 3246: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -1326,7 +1326,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels,
     // when we get here, filter_type contains the filter type, and line_buffer
     // contains the data
     filt[j * (x * n + 1)] = (unsigned char)filter_type;
-    STBIW_MEMMOVE(filt + j * (x * n + 1) + 1, line_buffer, x * n);
+    STBIW_MEMMOVE(filt + j * (x * n + 1) + 1, line_buffer, (size_t)x * (size_t)n);
   }
   STBIW_FREE(line_buffer);
   zlib = stbi_zlib_compress(filt, y * (x * n + 1), &zlen,


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3246](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3246)

To fix this without changing intended behavior, force the multiplication to occur in `size_t` so no intermediate `int` overflow occurs.

Best targeted change:
- In `include/stb_image_write.h` at the `STBIW_MEMMOVE` call around line 1329, change the third argument from `x * n` to `(size_t)x * (size_t)n` (or equivalent cast on one operand).
- This ensures multiplication is performed in an unsigned size type before passing length to `memmove`.

No new methods or dependencies are needed. No import changes are required (this header already uses `size_t` via standard headers in normal C/C++ environments).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
