### PR TITLE
Potential fix for code scanning alert no. 3245: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -1288,7 +1288,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels,
   filt = (unsigned char *)STBIW_MALLOC((x * n + 1) * y);
   if (!filt)
     return 0;
-  line_buffer = (signed char *)STBIW_MALLOC(x * n);
+  line_buffer = (signed char *)STBIW_MALLOC((size_t)x * (size_t)n);
   if (!line_buffer) {
     STBIW_FREE(filt);
     return 0;


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3245](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3245)

To fix this safely without changing behavior, ensure multiplication for allocation sizes is performed in `size_t` by casting **before** multiplication.  
The best minimal fix is to change line 1291 from:

- `STBIW_MALLOC(x * n)`

to:

- `STBIW_MALLOC((size_t)x * (size_t)n)`

This preserves functionality while preventing intermediate `int` overflow in that expression.  
File to edit: `include/stb_image_write.h` in `stbi_write_png_to_mem`, around line 1291.

No new methods or external dependencies are required. `size_t` is already available via existing includes (`<stdlib.h>`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
