### PR TITLE
Potential fix for code scanning alert no. 3244: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -1285,7 +1285,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels,
     force_filter = -1;
   }
 
-  filt = (unsigned char *)STBIW_MALLOC((x * n + 1) * y);
+  filt = (unsigned char *)STBIW_MALLOC((((size_t)x * (size_t)n) + 1u) * (size_t)y);
   if (!filt)
     return 0;
   line_buffer = (signed char *)STBIW_MALLOC(x * n);


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3244](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3244)

The fix is to ensure allocation-size arithmetic is performed in `size_t` (or another sufficiently wide unsigned type) **before** multiplication, and to preserve behavior otherwise.

Best minimal fix in `include/stb_image_write.h` at the `stbi_write_png_to_mem` allocation line:
- Change `(x * n + 1) * y` to a `size_t` expression, e.g. `((size_t)x * (size_t)n + 1u) * (size_t)y`.
- Keep existing logic and control flow unchanged.
- No new imports are required.

This removes the “multiply in int then widen” pattern that CodeQL flagged, without changing functional intent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
