### PR TITLE
Potential fix for code scanning alert no. 3243: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -1951,7 +1951,7 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n,
     return data;
   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
 
-  good = (stbi__uint16 *)stbi__malloc(req_comp * x * y * 2);
+  good = (stbi__uint16 *)stbi__malloc((size_t)req_comp * (size_t)x * (size_t)y * sizeof(stbi__uint16));
   if (good == NULL) {
     STBI_FREE(data);
     return (stbi__uint16 *)stbi__errpuc("outofmem", "Out of memory");


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3243](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3243)

Use `size_t`-typed arithmetic for the full allocation-size computation so multiplication is performed in the destination width, not in `unsigned int`/`int`. The minimal, behavior-preserving fix is to cast one operand at the start of the product chain (or each factor) to `size_t` and keep the rest unchanged.

In `include/stb_image.h`, at the allocation in `stbi__convert_format16` (around line 1954), replace:

- `stbi__malloc(req_comp * x * y * 2)`

with:

- `stbi__malloc((size_t)req_comp * (size_t)x * (size_t)y * sizeof(stbi__uint16))`

Using `sizeof(stbi__uint16)` avoids hardcoded `2` and preserves existing functionality while making intent explicit and portable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
