### PR TITLE
Potential fix for code scanning alert no. 3242: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -2084,8 +2084,8 @@ static stbi_uc *stbi__hdr_to_ldr(float *data, int x, int y, int comp) {
     n = comp - 1;
   for (i = 0; i < x * y; ++i) {
     for (k = 0; k < n; ++k) {
-      float z = (float)pow(data[i * comp + k] * stbi__h2l_scale_i,
-                           stbi__h2l_gamma_i) *
+      float z = (float)pow((double)data[i * comp + k] * (double)stbi__h2l_scale_i,
+                           (double)stbi__h2l_gamma_i) *
                     255 +
                 0.5f;
       if (z < 0)


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3242](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3242)

To fix this, force the multiplication to occur in `double` before calling `pow`, by casting one operand to `double` (preferably the indexed sample value). This preserves behavior for normal inputs while eliminating the pre-promotion overflow risk flagged by CodeQL.

In `include/stb_image.h`, within `stbi__hdr_to_ldr` around line 2087, update:
- from: `pow(data[i * comp + k] * stbi__h2l_scale_i, stbi__h2l_gamma_i)`
- to: `pow((double)data[i * comp + k] * (double)stbi__h2l_scale_i, (double)stbi__h2l_gamma_i)`

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
