### PR TITLE
Potential fix for code scanning alert no. 3241: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -5335,7 +5335,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw,
         stbi__create_png_alpha_expand8(dest, dest, x, img_n);
     } else if (depth == 8) {
       if (img_n == out_n)
-        memcpy(dest, cur, x * img_n);
+        memcpy(dest, cur, (size_t) x * (size_t) img_n);
       else
         stbi__create_png_alpha_expand8(dest, cur, x, img_n);
     } else if (depth == 16) {


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3241](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3241)

The correct fix is to cast one multiplicand to `size_t` before multiplication so arithmetic is performed in the larger type:

- Change `memcpy(dest, cur, x * img_n);`
- To `memcpy(dest, cur, (size_t)x * (size_t)img_n);`

This preserves behavior for valid ranges while removing intermediate overflow risk from smaller integer arithmetic.  
Edit only `include/stb_image.h` at the shown `depth == 8` / `img_n == out_n` branch around line 5338. No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
