### PR TITLE
Potential fix for code scanning alert no. 3240: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -6899,7 +6899,7 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp,
     out = (stbi_uc *)stbi__malloc_mad3(8, w, h, 0);
     ri->bits_per_channel = 16;
   } else
-    out = (stbi_uc *)stbi__malloc(4 * w * h);
+    out = (stbi_uc *)stbi__malloc((size_t)4 * (size_t)w * (size_t)h);
 
   if (!out)
     return stbi__errpuc("outofmem", "Out of memory");


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3240](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3240)

The correct fix is to force the allocation-size multiplication to be performed in `size_t` rather than `int`, so intermediate overflow cannot happen in `int` arithmetic.  
Best single change: in `include/stb_image.h` at the allocation line in the PSD loader branch (around line 6902), replace `stbi__malloc(4 * w * h)` with `stbi__malloc((size_t)4 * (size_t)w * (size_t)h)` (or equivalent `4u`/`size_t` promotion). This keeps functionality unchanged (same intended byte count), but ensures type-safe evaluation before passing to allocator. No new imports/dependencies are needed because `size_t` is already available via existing standard headers in this file context.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
