### PR TITLE
Potential fix for code scanning alert no. 3239: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7235,7 +7235,7 @@ static void *stbi__pic_load(stbi__context *s, int *px, int *py, int *comp,
   result = (stbi_uc *)stbi__malloc_mad3(x, y, 4, 0);
   if (!result)
     return stbi__errpuc("outofmem", "Out of memory");
-  memset(result, 0xff, x * y * 4);
+  memset(result, 0xff, (size_t)x * (size_t)y * 4u);
 
   if (!stbi__pic_load_core(s, x, y, comp, result)) {
     STBI_FREE(result);


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3239](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3239)

To fix this safely, ensure the multiplication is performed in `size_t` from the start by casting one operand before multiplication. That prevents intermediate `int` overflow and preserves behavior.

Best minimal fix in `include/stb_image.h` at the `memset` call in `stbi__pic_load`:

- Change `memset(result, 0xff, x * y * 4);`
- To `memset(result, 0xff, (size_t)x * (size_t)y * 4u);`

This keeps functionality the same (fill allocated RGBA buffer with `0xff`) while making arithmetic type-safe. No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
