### PR TITLE
Potential fix for code scanning alert no. 3238: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7566,7 +7566,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp,
 
   // clear my history;
   memset(g->history, 0x00,
-         g->w * g->h); // pixels that were affected previous frame
+         (size_t) g->w * (size_t) g->h); // pixels that were affected previous frame
 
   for (;;) {
     int tag = stbi__get8(s);


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3238](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3238)

To fix this safely, ensure multiplication is performed in `size_t` by casting **before** multiplication.  
Best minimal change: in `include/stb_image.h`, at the `memset` call around lines 7568–7569, change the third argument from `g->w * g->h` to `(size_t) g->w * (size_t) g->h`.

This preserves behavior for valid inputs while removing integer-overflow-in-`int` risk in the expression itself. No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
