### PR TITLE
Potential fix for code scanning alert no. 3237: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7561,7 +7561,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp,
     }
 
     // background is what out is after the undoing of the previou frame;
-    memcpy(g->background, g->out, 4 * g->w * g->h);
+    memcpy(g->background, g->out, (size_t)4 * (size_t)g->w * (size_t)g->h);
   }
 
   // clear my history;


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3237](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3237)

To fix this without changing functionality, force the multiplication to be performed in `size_t` by casting **before** multiplication begins.

Best targeted fix in `include/stb_image.h`:
- At the `memcpy` call on the flagged line (line ~7564), change:
  - `4 * g->w * g->h`
  - to
  - `(size_t)4 * (size_t)g->w * (size_t)g->h`

This preserves behavior for valid sizes, avoids `int` intermediate overflow, and directly satisfies the CodeQL rule. No new includes are needed (`size_t` is already available via existing headers).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
