### PR TITLE
Potential fix for code scanning alert no. 3236: Multiplication result converted to larger type

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7747,7 +7747,7 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
             delays_size = layers * sizeof(int);
           }
         } else {
-          out = (stbi_uc *)stbi__malloc(layers * stride);
+          out = (stbi_uc *)stbi__malloc((size_t)layers * (size_t)stride);
           if (!out)
             return stbi__load_gif_main_outofmem(&g, out, delays);
           out_size = layers * stride;


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/hybrid-compute/security/code-scanning/3236](https://github.com/bniladridas/hybrid-compute/security/code-scanning/3236)

General fix: ensure multiplication is performed in a wider unsigned size type (`size_t`) **before** the multiplication occurs, typically by casting one operand to `size_t`.

Best targeted fix here (without changing behavior): in `include/stb_image.h`, change the allocation call on line 7750 from `stbi__malloc(layers * stride)` to `stbi__malloc((size_t)layers * (size_t)stride)`. This preserves existing logic and return handling, but guarantees multiplication is done in `size_t`, eliminating `int`-overflow-before-conversion in this location.

No new imports, helper methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
