### PR TITLE
fix: combine alert fixes 3235–3249

### DIFF
--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7566,7 +7566,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp,
 
   // clear my history;
   memset(g->history, 0x00,
-         g->w * g->h); // pixels that were affected previous frame
+         (size_t) g->w * (size_t) g->h); // pixels that were affected previous frame
 
   for (;;) {
     int tag = stbi__get8(s);

--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -2084,8 +2084,8 @@ static stbi_uc *stbi__hdr_to_ldr(float *data, int x, int y, int comp) {
     n = comp - 1;
   for (i = 0; i < x * y; ++i) {
     for (k = 0; k < n; ++k) {
-      float z = (float)pow(data[i * comp + k] * stbi__h2l_scale_i,
-                           stbi__h2l_gamma_i) *
+      float z = (float)pow((double)data[i * comp + k] * (double)stbi__h2l_scale_i,
+                           (double)stbi__h2l_gamma_i) *
                     255 +
                 0.5f;
       if (z < 0)

--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7747,7 +7747,7 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
             delays_size = layers * sizeof(int);
           }
         } else {
-          out = (stbi_uc *)stbi__malloc(layers * stride);
+          out = (stbi_uc *)stbi__malloc((size_t)layers * (size_t)stride);
           if (!out)
             return stbi__load_gif_main_outofmem(&g, out, delays);
           out_size = layers * stride;

--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7235,7 +7235,7 @@ static void *stbi__pic_load(stbi__context *s, int *px, int *py, int *comp,
   result = (stbi_uc *)stbi__malloc_mad3(x, y, 4, 0);
   if (!result)
     return stbi__errpuc("outofmem", "Out of memory");
-  memset(result, 0xff, x * y * 4);
+  memset(result, 0xff, (size_t)x * (size_t)y * 4u);
 
   if (!stbi__pic_load_core(s, x, y, comp, result)) {
     STBI_FREE(result);

--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7723,39 +7723,50 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
         u = 0; // end of animated gif marker
 
       if (u) {
+        size_t alloc_size;
+        size_t delays_alloc;
         *x = g.w;
         *y = g.h;
         ++layers;
         stride = g.w * g.h * 4;
+        alloc_size = (size_t) layers * (size_t) stride;
+        if (alloc_size > (size_t) INT_MAX)
+          return stbi__load_gif_main_outofmem(&g, out, delays);
 
         if (out) {
           void *tmp =
-              (stbi_uc *)STBI_REALLOC_SIZED(out, out_size, layers * stride);
+              (stbi_uc *)STBI_REALLOC_SIZED(out, out_size, alloc_size);
           if (!tmp)
             return stbi__load_gif_main_outofmem(&g, out, delays);
           else {
             out = (stbi_uc *)tmp;
-            out_size = layers * stride;
+            out_size = (int) alloc_size;
           }
 
           if (delays) {
+            delays_alloc = (size_t) layers * sizeof(int);
+            if (delays_alloc > (size_t) INT_MAX)
+              return stbi__load_gif_main_outofmem(&g, out, delays);
             int *new_delays = (int *)STBI_REALLOC_SIZED(*delays, delays_size,
-                                                        sizeof(int) * layers);
+                                                        delays_alloc);
             if (!new_delays)
               return stbi__load_gif_main_outofmem(&g, out, delays);
             *delays = new_delays;
-            delays_size = layers * sizeof(int);
+            delays_size = (int) delays_alloc;
           }
         } else {
-          out = (stbi_uc *)stbi__malloc(layers * stride);
+          out = (stbi_uc *)stbi__malloc(alloc_size);
           if (!out)
             return stbi__load_gif_main_outofmem(&g, out, delays);
-          out_size = layers * stride;
+          out_size = (int) alloc_size;
           if (delays) {
-            *delays = (int *)stbi__malloc(layers * sizeof(int));
+            delays_alloc = (size_t) layers * sizeof(int);
+            if (delays_alloc > (size_t) INT_MAX)
+              return stbi__load_gif_main_outofmem(&g, out, delays);
+            *delays = (int *)stbi__malloc(delays_alloc);
             if (!*delays)
               return stbi__load_gif_main_outofmem(&g, out, delays);
-            delays_size = layers * sizeof(int);
+            delays_size = (int) delays_alloc;
           }
         }
         memcpy(out + ((layers - 1) * stride), u, stride);

--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -6899,7 +6899,7 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp,
     out = (stbi_uc *)stbi__malloc_mad3(8, w, h, 0);
     ri->bits_per_channel = 16;
   } else
-    out = (stbi_uc *)stbi__malloc(4 * w * h);
+    out = (stbi_uc *)stbi__malloc((size_t)4 * (size_t)w * (size_t)h);
 
   if (!out)
     return stbi__errpuc("outofmem", "Out of memory");

--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -1951,7 +1951,7 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n,
     return data;
   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
 
-  good = (stbi__uint16 *)stbi__malloc(req_comp * x * y * 2);
+  good = (stbi__uint16 *)stbi__malloc((size_t)req_comp * (size_t)x * (size_t)y * sizeof(stbi__uint16));
   if (good == NULL) {
     STBI_FREE(data);
     return (stbi__uint16 *)stbi__errpuc("outofmem", "Out of memory");

--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -5335,7 +5335,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw,
         stbi__create_png_alpha_expand8(dest, dest, x, img_n);
     } else if (depth == 8) {
       if (img_n == out_n)
-        memcpy(dest, cur, x * img_n);
+        memcpy(dest, cur, (size_t) x * (size_t) img_n);
       else
         stbi__create_png_alpha_expand8(dest, cur, x, img_n);
     } else if (depth == 16) {

--- a/include/stb_image.h
+++ b/include/stb_image.h
@@ -7561,7 +7561,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp,
     }
 
     // background is what out is after the undoing of the previou frame;
-    memcpy(g->background, g->out, 4 * g->w * g->h);
+    memcpy(g->background, g->out, (size_t)4 * (size_t)g->w * (size_t)g->h);
   }
 
   // clear my history;

--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -1288,7 +1288,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels,
   filt = (unsigned char *)STBIW_MALLOC((x * n + 1) * y);
   if (!filt)
     return 0;
-  line_buffer = (signed char *)STBIW_MALLOC(x * n);
+  line_buffer = (signed char *)STBIW_MALLOC((size_t)x * (size_t)n);
   if (!line_buffer) {
     STBIW_FREE(filt);
     return 0;

--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -1285,7 +1285,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels,
     force_filter = -1;
   }
 
-  filt = (unsigned char *)STBIW_MALLOC((x * n + 1) * y);
+  filt = (unsigned char *)STBIW_MALLOC((((size_t)x * (size_t)n) + 1u) * (size_t)y);
   if (!filt)
     return 0;
   line_buffer = (signed char *)STBIW_MALLOC(x * n);

--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -1326,7 +1326,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels,
     // when we get here, filter_type contains the filter type, and line_buffer
     // contains the data
     filt[j * (x * n + 1)] = (unsigned char)filter_type;
-    STBIW_MEMMOVE(filt + j * (x * n + 1) + 1, line_buffer, x * n);
+    STBIW_MEMMOVE(filt + j * (x * n + 1) + 1, line_buffer, (size_t)x * (size_t)n);
   }
   STBIW_FREE(line_buffer);
   zlib = stbi_zlib_compress(filt, y * (x * n + 1), &zlen,

--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -1211,7 +1211,7 @@ static void stbiw__encode_png_line(unsigned char *pixels, int stride_bytes,
       stbi__flip_vertically_on_write ? -stride_bytes : stride_bytes;
 
   if (type == 0) {
-    memcpy(line_buffer, z, width * n);
+    memcpy(line_buffer, z, (size_t)width * (size_t)n);
     return;
   }
 

--- a/include/stb_image_write.h
+++ b/include/stb_image_write.h
@@ -888,8 +888,8 @@ static void *stbiw__sbgrowf(void **arr, int increment, int itemsize) {
   int m = *arr ? 2 * stbiw__sbm(*arr) + increment : increment + 1;
   void *p = STBIW_REALLOC_SIZED(
       *arr ? stbiw__sbraw(*arr) : 0,
-      *arr ? (stbiw__sbm(*arr) * itemsize + sizeof(int) * 2) : 0,
-      itemsize * m + sizeof(int) * 2);
+      *arr ? ((size_t)stbiw__sbm(*arr) * (size_t)itemsize + (size_t)sizeof(int) * 2) : 0,
+      (size_t)itemsize * (size_t)m + (size_t)sizeof(int) * 2);
   STBIW_ASSERT(p);
   if (p) {
     if (!*arr)

--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -25,8 +26,21 @@ void splitImageIntoTiles(unsigned char *image, int width, int height,
     for (int x = 0; x < width; x += tile_size) {
       int tile_w = (x + tile_size > width) ? width - x : tile_size;
       int tile_h = (y + tile_size > height) ? height - y : tile_size;
-      unsigned char *tile_data =
-          (unsigned char *)malloc(tile_w * tile_h * channels);
+      if (tile_w <= 0 || tile_h <= 0 || channels <= 0) {
+        fprintf(stderr, "Invalid tile dimensions or channel count\n");
+        continue;
+      }
+      if ((size_t)tile_w > SIZE_MAX / (size_t)tile_h) {
+        fprintf(stderr, "Tile size overflow during allocation\n");
+        continue;
+      }
+      size_t tile_pixels = (size_t)tile_w * (size_t)tile_h;
+      if (tile_pixels > SIZE_MAX / (size_t)channels) {
+        fprintf(stderr, "Tile buffer overflow during allocation\n");
+        continue;
+      }
+      size_t tile_bytes = tile_pixels * (size_t)channels;
+      unsigned char *tile_data = (unsigned char *)malloc(tile_bytes);
       if (!tile_data) {
         fprintf(stderr, "Failed to allocate memory for tile\n");
         continue;


### PR DESCRIPTION
Combines all 15 automated code scanning alert fixes for multiplication result converted to larger type. These changes span `include/stb_image.h`, `include/stb_image_write.h`, and `src/preprocess.c` with consistent application of `size_t` casts to prevent integer overflow before conversion to larger types. Overflow checks are added where allocation sizes are stored back into `int` variables such as `out_size`.

> [!NOTE]
> Merging this pull request will automatically close #125, #126, #127, #128, #129, #130, #131, #132, #133, #134, #135, #136, #137, #138, #139

Close #125
Close #126
Close #127
Close #128
Close #129
Close #130
Close #131
Close #132
Close #133
Close #134
Close #135
Close #136
Close #137
Close #138
Close #139

## Discussion

- Merge blocked by unresolved threads: https://github.com/bniladridas/hybrid-compute/pull/140#issuecomment-4372672616