### PR TITLE
Add Stack section with architecture flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ It has a local API.
 
 <br>
 
+## Stack
+
+`hautofix → vortai → thread → mlapi`
+
+Depends on: vortai, mlapi.
+
+<br>
+
 # What Works Now
 
 | Part | State |


### PR DESCRIPTION
Identifies where thread sits in the palmshed stack: runtime foundation consumed by vortai and mlapi.